### PR TITLE
z-fighting fix between chunks

### DIFF
--- a/resources/js/meshworker/SurfaceNets.js
+++ b/resources/js/meshworker/SurfaceNets.js
@@ -152,6 +152,10 @@ class SurfaceNets{
           //Add vertex to buffer, store pointer to vertex index in buffer
           buffer[m] = vertices.length;
           vertices.push(v);
+
+          if ((x[0] === 0 || x[1] === 0 || x[2] === 0) && i < 6) {
+            continue;
+          }
           
           //Now we need to add faces together, to do this we just loop over 3 basis components
           for(var i=0; i<3; ++i) {


### PR DESCRIPTION
Hey, I think this fixes the z-fighting issue where chunks often generate overlapping faces on chunk boundaries. It prevents face generation for chunk grid cells at x,y,z=0,0,0 when considering edges on the left,bottom,back 3 sides of the grid cube. Please confirm if it is correct!